### PR TITLE
Add summary card component and styles

### DIFF
--- a/app/assets/stylesheets/_app-govuk-summary-card.scss
+++ b/app/assets/stylesheets/_app-govuk-summary-card.scss
@@ -1,0 +1,81 @@
+.app-govuk-summary-card {
+  border: 1px solid $govuk-border-colour;
+
+  // Card header
+  &__header {
+    align-items: center;
+    background-color: govuk-colour("light-grey");
+    padding: govuk-spacing(3);
+
+    @include govuk-media-query($from: desktop) {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+    }
+  }
+
+  &__title {
+    @include govuk-font($size: 19);
+    margin: 0;
+  }
+
+  &__meta {
+    @include govuk-font($size: 16);
+    display: block;
+    margin: 0;
+  }
+
+  &__actions {
+    @include govuk-font($size: 19);
+  }
+
+  &__actions-list {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__actions-list-item {
+    display: block;
+    white-space: nowrap;
+
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-left: govuk-spacing(2);
+      text-align: right;
+    }
+  }
+
+  &__actions-list-item:first-child {
+    margin-left: 0;
+  }
+
+  // Card body
+  &__body {
+    @include govuk-font($size: 19);
+    padding: govuk-spacing(3);
+  }
+
+  .govuk-summary-list {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__row:last-child,
+  .govuk-summary-list__row:last-child > * {
+    border-bottom: 0;
+  }
+}
+
+.app-govuk-summary-card--large-title .app-govuk-summary-card__title {
+  @include govuk-font($size: 24, $weight: bold);
+}
+
+@media print {
+  .app-govuk-summary-card__header {
+    break-inside: avoid;
+  }
+
+  .app-govuk-summary-card__actions {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -3,3 +3,4 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @import "govuk-frontend/govuk/all";
+@import "_app-govuk-summary-card";

--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -1,0 +1,6 @@
+<section class="app-govuk-summary-card govuk-!-margin-bottom-6 <%= border_css_class %>">
+  <%= content %>
+  <div class="app-govuk-summary-card__body">
+    <%= govuk_summary_list(rows: rows) %>
+  </div>
+</section>

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,0 +1,30 @@
+class SummaryCardComponent < ViewComponent::Base
+  def initialize(rows:, border: true, editable: true, ignore_editable: [])
+    super
+    rows = transform_hash(rows) if rows.is_a?(Hash)
+    @rows = rows_including_actions_if_editable(rows, editable, ignore_editable)
+    @border = border
+  end
+
+  def border_css_class
+    @border ? "" : "no-border"
+  end
+
+  private
+
+  attr_reader :rows, :ignore_editable
+
+  def rows_including_actions_if_editable(rows, editable, ignore_editable)
+    rows.map do |row|
+      row.tap do |r|
+        next if r[:key].in? ignore_editable
+
+        r.delete(:action) unless editable
+      end
+    end
+  end
+
+  def transform_hash(row_hash)
+    row_hash.map { |key, value| { key:, value: } }
+  end
+end

--- a/app/components/summary_card_header_component.html.erb
+++ b/app/components/summary_card_header_component.html.erb
@@ -1,0 +1,6 @@
+<header class="app-govuk-summary-card__header" <%= @anchor ? "id=#{@anchor}" : nil %>>
+  <h<%= @heading_level %> class="app-govuk-summary-card__title">
+    <%= @title %>
+  </h<%= @heading_level %>>
+  <%= content %>
+</header>

--- a/app/components/summary_card_header_component.rb
+++ b/app/components/summary_card_header_component.rb
@@ -1,0 +1,8 @@
+class SummaryCardHeaderComponent < ViewComponent::Base
+  def initialize(title:, heading_level: 2, anchor: nil)
+    super
+    @title = title
+    @heading_level = heading_level
+    @anchor = anchor
+  end
+end

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe SummaryCardComponent, type: :component do
+  let(:rows) do
+    [key: { text: "Character" }, value: { text: "Lando Calrissian" }]
+  end
+
+  it "renders a summary list component for rows" do
+    result = render_inline(described_class.new(rows:))
+    expect(result.css(".govuk-summary-list__value").text).to include(
+      "Lando Calrissian"
+    )
+    expect(result.css(".govuk-summary-list__key").text).to include("Character")
+  end
+
+  it "renders content at the top of a summary card" do
+    result = render_inline(described_class.new(rows:)) { "In a galaxy" }
+    expect(result.text).to include("In a galaxy")
+  end
+end

--- a/spec/components/summary_card_header_component_spec.rb
+++ b/spec/components/summary_card_header_component_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe SummaryCardHeaderComponent, type: :component do
+  it "renders a summary card header component with a title only" do
+    result = render_inline(described_class.new(title: "Lando Calrissian"))
+    expect(result.css(".app-govuk-summary-card__title").text).to include(
+      "Lando Calrissian"
+    )
+    expect(result.css(".app-govuk-summary-card__meta").text).not_to be_present
+    expect(result.css(".app-icon").text).not_to be_present
+  end
+
+  it "renders a summary card header component with a custom heading level" do
+    result =
+      render_inline(
+        described_class.new(title: "Lando Calrissian", heading_level: 6)
+      )
+    expect(result.css("h6.app-govuk-summary-card__title")).to be_present
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,6 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include ActiveSupport::Testing::TimeHelpers
+
+  config.include ViewComponent::TestHelpers, type: :component
 end


### PR DESCRIPTION
### Context

We will be using a similar summary card component to [find-a-lost-trn](https://github.com/DFE-Digital/find-a-lost-trn/pull/511) and this component hasn't fully made it into govuk-components

<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

- Adds styles for `.app-govuk-summary-card`
- Adds `SummaryCardComponent` and `SummaryCardHeaderComponent`

<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
