### PR TITLE
Shorten database password env var in production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,4 +17,4 @@ test:
 production:
   <<: *default
   database: access_your_teaching_profile_production
-  password: <%= ENV["ACCESS_YOUR_TEACHING_PROFILE_DATABASE_PASSWORD"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>


### PR DESCRIPTION
It's a bit verbose currently, settle on DATABASE_URL/DATABASE_PASSWORD in this file instead.

