### PR TITLE
Shorten database env var in production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,4 +17,4 @@ test:
 production:
   <<: *default
   database: access_your_teaching_profile_production
-  password: <%= ENV["ACCESS_YOUR_TEACHING_PROFILE_DATABASE_PASSWORD"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/access-your-teaching-profile/pull/24 intended to do this but base branch was not `main`
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Shorten production db env var from `ACCESS_YOUR_TEACHING_PROFILE_DATABASE_PASSWORD` to `DATABASE_PASSWORD`
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
