### PR TITLE
Enable SSH access for Azure

### DIFF
--- a/.ssh_setup
+++ b/.ssh_setup
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ssh-keygen -A
+
+#prepare run dir
+if [ ! -d "/var/run/sshd" ]; then
+  mkdir -p /var/run/sshd
+fi

--- a/.sshd_config
+++ b/.sshd_config
@@ -1,0 +1,12 @@
+Port      2222
+ListenAddress     0.0.0.0
+LoginGraceTime    180
+X11Forwarding     yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr
+MACs hmac-sha1,hmac-sha1-96
+StrictModes     yes
+SyslogFacility    DAEMON
+PasswordAuthentication  yes
+PermitEmptyPasswords  no
+PermitRootLogin   yes
+Subsystem sftp internal-sftp

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,20 @@ RUN apk add --no-cache libpq
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+# SSH access specific to Azure
+# Install OpenSSH and set the password for root to "Docker!".
+RUN apk add --no-cache openssh && echo "root:Docker!" | chpasswd
+
+# Copy the sshd_config file to the /etc/ssh/ directory
+COPY .sshd_config /etc/ssh/sshd_config
+
+# Copy and configure the ssh_setup file
+RUN mkdir -p /tmp
+COPY .ssh_setup /tmp/ssh_setup.sh
+RUN chmod +x /tmp/ssh_setup.sh && (sleep 1;/tmp/ssh_setup.sh 2>&1 > /dev/null)
+
+# Open port 2222 for SSH access
+EXPOSE 80 2222
+
 CMD bundle exec rails db:migrate && \
     bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context

We'd like to access application logs and other useful information. Azure has specific SSH configuration instructions which allow access via the Azure UI only...
https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#enable-ssh
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Add Azure specific SSH config.
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/ZMLvLvcK/178-setup-deploy-pipeline-for-access-your-teaching-profile
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
