### PR TITLE
Add basic okcomputer config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "okcomputer"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
+    okcomputer (1.18.4)
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
@@ -346,6 +347,7 @@ DEPENDENCIES
   govuk-components
   govuk_design_system_formbuilder
   jsbundling-rails
+  okcomputer
   pg (~> 1.1)
   prettier_print
   propshaft

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,8 @@
+OkComputer.logger = Rails.logger
+OkComputer.mount_at = "health"
+
+OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new
+
+OkComputer::Registry.register "version", OkComputer::AppVersionCheck.new
+
+OkComputer.make_optional %w[version]

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Health check", type: :request do
+  it "responds successfully" do
+    get "/health"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "checks PostgreSQL health" do
+    get "/health/postgresql"
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
### Context

Azure polls `/health` which is currently returning a 404.
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Adds a basic `okcomputer` config for `/health`, we should add relevant Sidekiq and Notify checks when appropriate.
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/ZMLvLvcK/178-setup-deploy-pipeline-for-access-your-teaching-profile
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
