### PR TITLE
Add asset builds in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,6 +24,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # Necessary for precompiled assets in production mode.
+  config.assets.paths << Rails.root.join("app/assets/builds")
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 


### PR DESCRIPTION
### Context

Compiled assets end up in `app/assets/builds` but this path isn't automatically configured in production.
When deploying to Azure we get the default web server 500 page as the base application CSS file can't be found. 

<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Add `app/assets/builds` to the asset paths in `RAILS_ENV=production` environments
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/ZMLvLvcK/178-setup-deploy-pipeline-for-access-your-teaching-profile

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
