### PR TITLE
Add a `GET /_sha` endpoint to expose Git SHA

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root to: "pages#home"
+  get "_sha", to: ->(_) { [200, {}, [`git rev-parse HEAD`.chomp]] }
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/spec/requests/sha_spec.rb
+++ b/spec/requests/sha_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Git SHA", type: :request do
+  it "responds successfully" do
+    get "/_sha"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "responds with the current Git SHA" do
+    get "/_sha"
+    expect(response.body).to eq(`git rev-parse HEAD`.chomp)
+  end
+end


### PR DESCRIPTION
### Context

Necessary for build pipeline work
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Add `GET /_sha` endpoint which responds with current Git SHA
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/FDJp2OVb/215-deploy-dev-environment
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
