### PR TITLE
Read Git SHA from ENV

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root to: "pages#home"
-  get "_sha", to: ->(_) { [200, {}, [`git rev-parse HEAD`.chomp]] }
+  get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/sha_spec.rb
+++ b/spec/requests/sha_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe "Git SHA", type: :request do
   end
 
   it "responds with the current Git SHA" do
+    allow(ENV).to receive(:fetch).with("GIT_SHA", "").and_return(
+      "6f30ff56b31aed931866f8845a44ae9930934192"
+    )
+
     get "/_sha"
-    expect(response.body).to eq(`git rev-parse HEAD`.chomp)
+    expect(response.body).to eq("6f30ff56b31aed931866f8845a44ae9930934192")
   end
 end


### PR DESCRIPTION
### Context

We can't invoke git in a docker container so the SHA has to come from the env.

<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Amend `GET /_sha` to read from `GIT_SHA` env var.
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/FDJp2OVb/215-deploy-dev-environment
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
