### PR TITLE
Add Azure specific sshd config and startup

### DIFF
--- a/.ssh_setup
+++ b/.ssh_setup
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-ssh-keygen -A
-
-#prepare run dir
-if [ ! -d "/var/run/sshd" ]; then
-  mkdir -p /var/run/sshd
-fi

--- a/.sshd_config
+++ b/.sshd_config
@@ -1,0 +1,12 @@
+Port      2222
+ListenAddress     0.0.0.0
+LoginGraceTime    180
+X11Forwarding     yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr
+MACs hmac-sha1,hmac-sha1-96
+StrictModes     yes
+SyslogFacility    DAEMON
+PasswordAuthentication  yes
+PermitEmptyPasswords  no
+PermitRootLogin   yes
+Subsystem sftp internal-sftp


### PR DESCRIPTION
### Context

We didn't quite get this working with Azure when introducing the dev build pipeline, it turns out that `sshd` was not started correctly on the runtime container.

See https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#enable-ssh
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

- Remove `.ssh_setup` - we make these changes with docker `RUN` commands on the container.
- Add Azure specific `sshd_config` to runtime container.
- Open port `2222` specific to Azure container SSH connectivity.
- Start `sshd` as part of the container `CMD` directive.

<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

Running docker locally I could see sshd running and accepting connections on port `2222` on the runtime container and the appropriate config in place in `/etc/ssh/sshd_config`.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
