### PR TITLE
Add markdown content support & markdown driven pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,11 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Healthcheck pages
 gem "okcomputer"
+
+# Markdown content pages
+gem "govuk_markdown"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 0.9, >= 0.9.2)
+    govuk_markdown (1.0.0)
+      activesupport
+      redcarpet
     haml (6.0.0)
       temple (>= 0.8.2)
       thor
@@ -213,6 +216,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rbs (2.6.0)
+    redcarpet (3.5.1)
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -346,6 +350,7 @@ DEPENDENCIES
   dotenv-rails
   govuk-components
   govuk_design_system_formbuilder
+  govuk_markdown
   jsbundling-rails
   okcomputer
   pg (~> 1.4)

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class StaticController < ApplicationController
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: "GOV.UK Rails Boilerplate") do |header| %>
+    <%= govuk_header(service_name: t('service.name')) do |header| %>
       <%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
       <%= header.navigation_item(text: "Navigation item 2", href: "#") %>
       <%= header.navigation_item(text: "Navigation item 3", href: "#") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,10 @@
       </main>
     </div>
 
-    <%= govuk_footer %>
+    <%= govuk_footer(meta_items: [
+      { text: "Accessibility", href: accessibility_path },
+      { text: "Cookies", href: cookies_path },
+      { text: "Privacy notice", href: privacy_path },
+    ]) %>
   </body>
 </html>

--- a/app/views/static/accessibility.md
+++ b/app/views/static/accessibility.md
@@ -1,0 +1,93 @@
+<% content_for :page_title, 'Accessibility statement' %>
+
+# Accessibility statement for <%= t('service.name') %>
+
+This page only contains information about the <%= t('service.name') %>
+service, available at: <a href="<%= t('service.url') %>" class="govuk-link
+govuk-link--no-visited-state"> <%= t('service.url') %> </a>
+
+## Using this service
+
+This service is run by the Department for Education. We want as many people as
+possible to be able to use this service.
+
+For example, that means you should be able to:
+
+- change colours, contrast levels and fonts
+- zoom in up to 300% without the text spilling off the screen
+- get from the start of the service to the end using just a keyboard
+- get from the start of the service to the end using speech recognition
+  software
+- listen to the service using a screen reader (including the most recent
+  versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the text in the service as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device
+easier to use if you have a disability.
+
+## How accessible this service is
+
+This service is fully compliant with [the Web Content Accessibility Guidelines
+version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
+
+## Feedback and contact information
+
+If you have difficulty using this service, email: <a href="mailto:<%=
+t('service.email') %>" class="govuk-link govuk-link--no-visited-state"><%=
+t('service.email') %></a>
+
+As part of providing this service, we may need to send you messages or
+documents. We'll ask you how you want us to send messages or documents to you,
+but contact us if you need them in a different format, for example, large print,
+audio recording or braille.
+
+## Reporting accessibility problems with this service
+
+We’re always looking to improve the accessibility of this service.
+
+If you find any problems that are not listed on this page or think we’re not
+meeting accessibility requirements, email: <a href="mailto:<%= t('service.email')
+%>" class="govuk-link govuk-link--no-visited-state"><%= t('service.email') %></a>
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing
+the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+Accessibility Regulations 2018 (the ‘accessibility regulations’).
+
+If you’re not happy with how we respond to your complaint, contact [the
+Equality Advisory and Support Service
+(EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this service’s accessibility
+
+The Department for Education is committed to making this service accessible, in
+accordance with the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This service is fully compliant with [the Web Content Accessibility Guidelines
+version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
+
+## What we are doing to improve accessibility
+
+We’ll carry out ongoing internal audits to check the accessibility of this
+service as well as taking feedback from users.
+
+Any required changes will be planned into our continuous improvement work for
+this service.
+
+This accessibility statement will be updated based on any issues we identify or
+any changes we make to address any issues raised.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on Tuesday 5 April 2022. It was last reviewed on
+Tuesday 21 June 2022.
+
+This service was last tested on Monday 16 May 2022. The test was carried
+out by the DFE Accessibility team.
+
+Last updated: Tuesday 21 June 2022

--- a/app/views/static/cookies.md
+++ b/app/views/static/cookies.md
@@ -1,0 +1,38 @@
+<% content_for :page_title, 'Cookies' %>
+
+# Cookies
+
+Cookies are small files saved on your phone, tablet or computer when you visit
+a website.
+
+We use cookies to make the <%= t('service.name') %> service work and
+collect information about how you use our service.
+
+## Essential cookies
+
+Essential cookies keep your information secure while you use the <%=
+t('service.name') %> service. We do not need to ask permission to use them.
+
+<table class="govuk-table">
+  <caption class="govuk-visually-hidden">Essential cookies</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Name</th>
+      <th class="govuk-table__header">Purpose</th>
+      <th class="govuk-table__header">Expires</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        _session_id
+      </td>
+      <td class="govuk-table__cell" width="50%">
+        Used to keep you signed in
+      </td>
+      <td class="govuk-table__cell">
+        2 hours
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/static/privacy.md
+++ b/app/views/static/privacy.md
@@ -1,0 +1,103 @@
+<% content_for :page_title, 'Privacy notice' %>
+
+# Privacy notice
+
+## Who we are
+
+The <%= t('service.name') %> service is run by the [Teaching Regulation Agency
+(TRA)](https://www.gov.uk/government/organisations/teaching-regulation-agency/about),
+an executive agency of the Department for Education (DfE).
+
+Our service allows anyone ...
+
+For the purpose of data protection legislation, DfE is the data controller for
+the data we hold and process.
+
+## What data we collect
+
+We collect your:
+
+- full name
+- date of birth
+- National Insurance number
+- initial teacher training (ITT) provider (where you gained qualified teacher
+  status (QTS) or early years teacher status (EYTS))
+- email address
+
+### Why we need your data
+
+We need to collect this data so we can ...
+
+## Our legal basis for processing your data
+
+So that our use of your personal data is lawful, we need to meet one (or more)
+conditions in the data protection legislation. For our service, this is:
+
+- article 6(1)(e) UK General Data Protection Regulation (UK GDPR), to perform a
+  public task carried out in the public interest as part of our function as a
+  department
+
+### What we do with your data
+
+We use the data you give us to ...
+
+We might also use your details when analysing data to improve the service.
+
+We use Microsoft Azure to run the service. [Visit the GOV.UK PaaS
+website](https://azure.microsoft.com/en-gb/explore/trusted-cloud/privacy/)
+to find out how they use and look after your data.
+
+## How long we keep your data
+
+We’ll keep a record for ...
+
+## Your data protection rights
+
+You have the right:
+
+- to ask us what information we hold about you
+- to have your personal data rectified if it is inaccurate or incomplete
+- to request the deletion or removal of personal data where there is no
+  compelling reason for its continued processing
+- to restrict our processing of your personal data (for instance allow us to
+  store it but not process it further)
+- to object to direct marketing (including profiling) and processing for the
+  purposes of scientific or historical research and statistics
+- not to be subject to decisions based purely on automated processing where it
+  produces a legal or similarly significant effect on you
+
+If you have any questions about how we’ll use your personal information,
+email [qts.enquiries@education.gov.uk](mailto:qts.enquiries@education.gov.uk)
+and enter ‘Data protection enquiry’ as a reference.
+
+You can also contact the Data Protection Office by emailing
+[dataprotection.office@education.gov.uk](mailto:dataprotection.office@education.gov.uk).
+
+You can find further information about your data protection rights on
+the [Information Commissioner’s
+website](https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/).
+
+### Consent and how to make a complaint
+
+As we have a clear purpose for processing your personal data, we would not
+explicitly seek your consent to process your data.
+
+If you’re unhappy with our use of your personal data, please
+email [qts.enquiries@education.gov.uk](mailto:qts.enquiries@education.gov.uk).
+
+You can also contact the DfE Data Protection Office:
+
+Deputy Director, Departmental Data Protection Officer<br />
+Wellington Place<br />
+Leeds<br />
+LS1 4AP<br />
+[data.protection@education.gov.uk](mailto:data.protection@education.gov.uk)
+
+Alternatively, you have the right to raise any concerns with the [Information
+Commissioner’s Office (ICO)](https://ico.org.uk/concerns/).
+
+## Changes to this notice
+
+We’ll update this privacy notice when required. You should review it at least once a year.
+
+This version was last updated on 12th October 2022.

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MarkdownTemplate
+  def self.call(template, source)
+    erb_handler = ActionView::Template.registered_template_handler(:erb)
+    compiled_source = erb_handler.call(template, source)
+    "GovukMarkdown.render(begin;#{compiled_source};end).html_safe"
+  end
+end
+
+ActionView::Template.register_template_handler :md, MarkdownTemplate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
 en:
   service:
-    name: GOV.UK Frontend on Rails
+    name: Access your teaching profile
     email: my-service@email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,4 @@ en:
   service:
     name: Access your teaching profile
     email: my-service@email
+    url: https://www.access-your-teaching-profile.service.gov.uk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   root to: "pages#home"
   get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
 
+  get "/accessibility", to: "static#accessibility"
+  get "/cookies", to: "static#cookies"
+  get "/privacy", to: "static#privacy"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/spec/requests/view_static_pages_spec.rb
+++ b/spec/requests/view_static_pages_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Static markdown pages" do
+  include Capybara::RSpecMatchers
+
+  describe "GET /accessibility" do
+    it "renders accessibility guidance" do
+      get "/accessibility"
+
+      expect(response).to be_successful
+      expect(response.body).to have_selector("h1", text: "Accessibility")
+      expect(response.body).to have_selector("h2", text: "Using this service")
+    end
+  end
+
+  describe "GET /cookies" do
+    it "renders the cookies guidance" do
+      get "/cookies"
+
+      expect(response).to be_successful
+      expect(response.body).to have_selector("h1", text: "Cookies")
+      expect(response.body).to have_selector("h2", text: "Essential cookies")
+      expect(response.body).to have_selector("table thead th", text: "Expires")
+      expect(response.body).to have_selector(
+        "p",
+        text: /Access your teaching profile service/
+      )
+    end
+  end
+
+  describe "GET /privacy" do
+    it "renders privacy guidance" do
+      get "/privacy"
+
+      expect(response).to be_successful
+      expect(response.body).to have_selector("h1", text: "Privacy notice")
+      expect(response.body).to have_selector("h2", text: "What data we collect")
+      expect(response.body).to have_selector(
+        "p",
+        text: /Access your teaching profile service/
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/NE9yGpsk/192-access-your-teaching-profile-improvements

We'd like to write static content pages like /cookies in markdown.
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

- Add a markdown helper and rendering template
- Add accessibility page
- Add cookies page
- Add privacy notice page
<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/195128931-978fb334-a4d5-4718-bae9-18a09f220482.png)


### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/NE9yGpsk/192-access-your-teaching-profile-improvements
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
