### PR TITLE
Add the assets/builds path to test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
+  # Necessary for precompiled assets in test mode.
+  config.assets.paths << Rails.root.join("app/assets/builds")
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
### Context

Tests where the page is rendered are failing on CI with the error:

```
ActionView::Template::Error:
       The asset 'application.css' was not found in the load path.
```

(see https://github.com/DFE-Digital/access-your-teaching-profile/actions/runs/3228029090/jobs/5283593447)
<!-- Why are you making this change? What might surprise someone about it? -->

### Changes proposed in this pull request

Add `app/assets/builds` to the assets load path
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
