### PR TITLE
Add basic support interface

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,6 @@
+DQT_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
+DQT_API_KEY=testkey
+HOSTING_DOMAIN=http://localhost:3000
+HOSTING_ENVIRONMENT_NAME=test
+SUPPORT_USERNAME=test
+SUPPORT_PASSWORD=test

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "cuprite"
   gem "selenium-webdriver"
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.1)
       railties (>= 6.0.0)
+    cuprite (0.14.2)
+      capybara (~> 3.0)
+      ferrum (~> 0.12.0)
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -104,6 +107,11 @@ GEM
       railties (>= 3.2)
     e2mmap (0.1.0)
     erubi (1.11.0)
+    ferrum (0.12)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govuk-components (3.2.1)
@@ -352,6 +360,7 @@ DEPENDENCIES
   bootsnap
   capybara
   cssbundling-rails
+  cuprite
   debug
   dotenv-rails
   govuk-components

--- a/app/controllers/support_interface/feature_flags_controller.rb
+++ b/app/controllers/support_interface/feature_flags_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module SupportInterface
+  class FeatureFlagsController < SupportInterfaceController
+    def index
+      @features = FeatureFlag::FEATURES
+    end
+
+    def activate
+      FeatureFlag.activate(params[:feature_name])
+
+      flash[:success] = "Feature “#{feature_name}” activated"
+      redirect_to support_interface_features_path
+    end
+
+    def deactivate
+      FeatureFlag.deactivate(params[:feature_name])
+
+      flash[:success] = "Feature “#{feature_name}” deactivated"
+      redirect_to support_interface_features_path
+    end
+
+    private
+
+    def feature_name
+      params[:feature_name].humanize
+    end
+  end
+end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module SupportInterface
+  class SupportInterfaceController < ApplicationController
+    layout "support_layout"
+
+    http_basic_authenticate_with name: ENV["SUPPORT_USERNAME"],
+                                 password: ENV["SUPPORT_PASSWORD"]
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,34 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
+  def current_namespace
+    section = request.path.split("/").second
+    section == "support" ? "support_interface" : "find_interface"
+  end
+
+  def custom_title(page_title)
+    [page_title, service_name].compact.join(" - ")
+  end
+
+  def custom_header
+    govuk_header(
+      homepage_url: t("govuk.url"),
+      service_name: t("service.name"),
+      service_url: t("service.url")
+    ) do |header|
+      case try(:current_namespace)
+      when "support_interface"
+        header.navigation_item(
+          active: current_page?(support_interface_features_path),
+          href: support_interface_features_path,
+          text: "Features"
+        )
+        header.navigation_item(
+          active: false,
+          href: support_interface_sidekiq_web_path,
+          text: "Sidekiq"
+        )
+      end
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,11 +27,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: t('service.name')) do |header| %>
-      <%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%= header.navigation_item(text: "Navigation item 2", href: "#") %>
-      <%= header.navigation_item(text: "Navigation item 3", href: "#") %>
-    <% end %>
+    <%= custom_header %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,0 +1,1 @@
+<%= render template: 'layouts/application' %>

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_title, 'Features' %>
+
+<h1 class="govuk-heading-l">Features</h1>
+
+<% @features.each do |feature_name, feature_flag| %>
+  <h2 class="govuk-heading-m">
+    <%= feature_name.humanize %>
+    <span class="govuk-visually-hidden">
+      - <%= FeatureFlag.active?(feature_name) ? 'Active' : 'Inactive' %>
+    </span>
+  </h2>
+  <% rows = [
+      { key: { text: 'Description'},
+        value: { text: feature_flag.description },
+      },
+      { key: { text: 'Status'},
+        value: {
+          text: govuk_tag(
+            text: FeatureFlag.active?(feature_name) ? 'Active' : 'Inactive',
+            colour: FeatureFlag.active?(feature_name) ? 'green' : 'grey',
+          )
+        },
+      },
+      { key: { text: 'Owner'},
+        value: { text: feature_flag.owner },
+      },
+  ] %>
+  <%= govuk_summary_list(rows: rows) %>
+  <% if FeatureFlag.active?(feature_name) then %>
+    <%= form_with(url: support_interface_deactivate_feature_path(feature_name)) do |f| %>
+      <%= form_with(url: support_interface_deactivate_feature_path(feature_name)) do |f| %>
+        <%= f.govuk_submit 'Deactivate ' + feature_name.humanize, prevent_double_click: false %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= form_with(url: support_interface_activate_feature_path(feature_name)) do |f| %>
+      <%= f.govuk_submit 'Activate ' + feature_name.humanize, prevent_double_click: false %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/support_interface/support_interface/home.html.erb
+++ b/app/views/support_interface/support_interface/home.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Support home</h1>
+    <p class="govuk-body">
+      You can delete this action/view once we have support pages.
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   root to: "pages#home"
   get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
@@ -6,10 +8,19 @@ Rails.application.routes.draw do
   get "/cookies", to: "static#cookies"
   get "/privacy", to: "static#privacy"
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  namespace :support_interface, path: "/support" do
+    get "/", to: redirect("/support/features")
 
-  # Defines the root path route ("/")
-  # root "articles#index"
+    get "/features", to: "feature_flags#index"
+    post "/features/:feature_name/activate",
+         to: "feature_flags#activate",
+         as: :activate_feature
+    post "/features/:feature_name/deactivate",
+         to: "feature_flags#deactivate",
+         as: :deactivate_feature
+
+    mount Sidekiq::Web, at: "sidekiq"
+  end
 
   scope via: :all do
     get "/404", to: "errors#not_found"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,7 @@ Capybara.register_driver(:cuprite) do |app|
     app,
     timeout: 10,
     process_timeout: 30,
-    window_size: [1200, 800],
+    window_size: [1200, 800]
   )
 end
 Capybara.default_driver = :cuprite

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,20 @@ if Rails.env.production?
   abort("The Rails environment is running in production mode!")
 end
 require "rspec/rails"
+require "capybara/rspec"
+require "capybara/cuprite"
+
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    timeout: 10,
+    process_timeout: 30,
+    window_size: [1200, 800],
+  )
+end
+Capybara.default_driver = :cuprite
+Capybara.javascript_driver = :cuprite
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Support", type: :system do
+  before { driven_by(:rack_test) }
+
+  it "visiting the support interface" do
+    when_i_am_authorized_as_a_support_user
+    and_i_visit_the_support_page
+    then_i_see_the_features_page
+  end
+
+  private
+
+  def when_i_am_authorized_as_a_support_user
+    page.driver.browser.basic_authorize(
+      ENV["SUPPORT_USERNAME"],
+      ENV["SUPPORT_PASSWORD"]
+    )
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def then_i_see_the_features_page
+    expect(page).to have_content("Features")
+  end
+end


### PR DESCRIPTION
### Context

AYTP will (eventually) need a support interface behind basic auth.

### Changes proposed in this pull request

Adds a support interface with Feature management page and Sidekiq dashboard. 

![image](https://user-images.githubusercontent.com/93511/196427569-f5cebf7d-8c26-4efc-9312-084acbe32a24.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/NE9yGpsk/192-access-your-teaching-profile-improvements

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
